### PR TITLE
Add valuation module with basic DCF and comps analysis

### DIFF
--- a/tests/test_valuation.py
+++ b/tests/test_valuation.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path as _Path
+sys.path.insert(0, str(_Path(__file__).resolve().parents[1]))
+
+from pathlib import Path
+import json
+import builtins
+import types
+
+import pytest
+
+from valuation import load_assumptions, dcf_valuation, comps_valuation, run_valuation, ValuationResult
+
+
+def test_load_assumptions(tmp_path: Path) -> None:
+    yaml_content = """
+    wacc: 0.1
+    growth: 0.03
+    comps_multiple: 6
+    """
+    f = tmp_path / "assumptions.yml"
+    f.write_text(yaml_content)
+    data = load_assumptions(f)
+    assert data["wacc"] == 0.1
+    assert data["growth"] == 0.03
+    assert data["comps_multiple"] == 6
+
+
+def test_dcf_comps_and_run_valuation() -> None:
+    financials = {
+        "free_cash_flow": [100.0, 110.0, 120.0],
+        "ebitda": 150.0,
+    }
+    assumptions = {"wacc": 0.1, "growth": 0.03, "comps_multiple": 6}
+
+    dcf_val = dcf_valuation(financials, 0.1, 0.03)
+    assert dcf_val > 0
+
+    comps_val = comps_valuation(financials, 6)
+    assert comps_val == 900.0
+
+    result = run_valuation(financials, assumptions)
+    assert isinstance(result, ValuationResult)
+    assert result.enterprise_value > 0
+    assert "high" in result.sensitivity and "low" in result.sensitivity

--- a/valuation.py
+++ b/valuation.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Mapping, Sequence
+
+
+@dataclass
+class ValuationResult:
+    enterprise_value: float
+    methodology: str
+    sensitivity: Dict[str, float]
+
+
+def load_assumptions(path: str | Path) -> Dict[str, float]:
+    """Load simple key:value assumptions from a YAML file."""
+    assumptions: Dict[str, float] = {}
+    p = Path(path)
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        assumptions[key.strip()] = float(value.strip())
+    return assumptions
+
+
+def _get_item(data: Any, key: str) -> Any:
+    if isinstance(data, Mapping):
+        return data[key]
+    try:
+        return data[key]
+    except Exception:
+        return getattr(data, key)
+
+
+def dcf_valuation(financials: Any, wacc: float, growth: float) -> float:
+    """Calculate enterprise value using a simple DCF model."""
+    cash_flows: Sequence[float] = list(_get_item(financials, "free_cash_flow"))
+    pv = 0.0
+    for i, cf in enumerate(cash_flows, start=1):
+        pv += cf / (1 + wacc) ** i
+    terminal_cf = cash_flows[-1] * (1 + growth)
+    terminal_value = terminal_cf / (wacc - growth)
+    terminal_pv = terminal_value / (1 + wacc) ** len(cash_flows)
+    return pv + terminal_pv
+
+
+def comps_valuation(financials: Any, multiple: float, key: str = "ebitda") -> float:
+    """Apply a comps multiple to a financial metric."""
+    metric = float(_get_item(financials, key))
+    return metric * multiple
+
+
+def run_valuation(financials: Any, assumptions: Mapping[str, float]) -> ValuationResult:
+    """Run DCF and comps valuations and return a JSON-ready result."""
+    wacc = float(assumptions["wacc"])
+    growth = float(assumptions["growth"])
+    multiple = float(assumptions["comps_multiple"])
+
+    dcf_value = dcf_valuation(financials, wacc, growth)
+    comps_value = comps_valuation(financials, multiple)
+    enterprise_value = (dcf_value + comps_value) / 2
+
+    sens_high = dcf_valuation(financials, wacc * 0.9, growth)
+    sens_low = dcf_valuation(financials, wacc * 1.1, growth)
+    sensitivity = {"high": sens_high, "low": sens_low}
+
+    return ValuationResult(
+        enterprise_value=enterprise_value,
+        methodology="DCF and Comps",
+        sensitivity=sensitivity,
+    )
+
+
+__all__ = [
+    "ValuationResult",
+    "load_assumptions",
+    "dcf_valuation",
+    "comps_valuation",
+    "run_valuation",
+]


### PR DESCRIPTION
## Summary
- implement `valuation.py` providing DCF and comps valuation logic
- include helper to load numeric assumptions from YAML
- add tests covering valuation functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865c2fcecf0832a83949303a6942bae