### PR TITLE
Add utility helper functions and tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from utils import get_current_utc, safe_slugify, calculate_sha256
+
+
+def test_get_current_utc_timezone() -> None:
+    ts = get_current_utc()
+    assert ts.tzinfo is timezone.utc
+    now = datetime.now(timezone.utc)
+    assert abs((now - ts).total_seconds()) < 2
+
+
+def test_safe_slugify() -> None:
+    assert safe_slugify("Hello, World!") == "hello-world"
+    assert safe_slugify(" Multiple   spaces ") == "multiple-spaces"
+    assert safe_slugify("special__chars!*&") == "special-chars"
+
+
+def test_calculate_sha256(tmp_path: Path) -> None:
+    file_path = tmp_path / "test.txt"
+    data = b"sample data"
+    file_path.write_bytes(data)
+    expected = hashlib.sha256(data).hexdigest()
+    assert calculate_sha256(file_path) == expected

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import re
+from pathlib import Path
+
+__all__ = [
+    "get_current_utc",
+    "safe_slugify",
+    "calculate_sha256",
+]
+
+_slug_pattern = re.compile(r"[^a-zA-Z0-9]+")
+
+
+def get_current_utc() -> datetime:
+    """Return the current UTC time as an aware ``datetime`` object."""
+    return datetime.now(timezone.utc)
+
+
+def safe_slugify(value: str) -> str:
+    """Return a filesystem and URL safe slug representation of ``value``."""
+    value = value.strip().lower()
+    value = _slug_pattern.sub("-", value)
+    return value.strip("-")
+
+
+def calculate_sha256(path: Path) -> str:
+    """Return the hexadecimal SHA-256 digest of the file at ``path``."""
+    hash_obj = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            hash_obj.update(chunk)
+    return hash_obj.hexdigest()


### PR DESCRIPTION
## Summary
- add `get_current_utc`, `safe_slugify`, and `calculate_sha256` utilities
- test the new utility helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865c32f366c832ab636b0aab4f4ba52